### PR TITLE
Remove needless environment variable definition

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,5 @@
 FROM nginx:1.17.9
 
-ENV NGINX_VERSION=1.17.9
 ENV NGX_MRUBY_VERSION=2.2.0
 
 RUN apt-get update && apt-get install --no-install-recommends --no-install-suggests -y \


### PR DESCRIPTION
Remove needless environment variable definition. `NGINX_VERSION` is defined in the base image.