### PR TITLE
Adjust NGX_MRUBY_VERSION environment variable

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -30,5 +30,7 @@ RUN apt-get update && apt-get install --no-install-recommends --no-install-sugge
 
 FROM nginx:1.17.9
 
+ENV NGX_MRUBY_VERSION 2.2.0
+
 COPY --from=0 /usr/local/src/nginx-$NGINX_VERSION/objs/*.so /etc/nginx/modules/
 COPY nginx.conf /etc/nginx/nginx.conf

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM nginx:1.17.9
 
-ENV NGX_MRUBY_VERSION=2.2.0
+ENV NGX_MRUBY_VERSION 2.2.0
 
 RUN apt-get update && apt-get install --no-install-recommends --no-install-suggests -y \
     git \


### PR DESCRIPTION
Adjust NGX_MRUBY_VERSION environment variable.

- Fix `ENV` instruction form in `Dockerfile`.
- Enable to refer `NGX_MRUBY_VERSION` environment variable from final image.