### PR TITLE
Update ngx_mruby to v2.2.5 in stable nginx image

### DIFF
--- a/stable/Dockerfile
+++ b/stable/Dockerfile
@@ -1,6 +1,6 @@
 FROM nginx:1.22.0
 
-ENV NGX_MRUBY_VERSION 2.2.4
+ENV NGX_MRUBY_VERSION 2.2.5
 
 COPY build_config.rb /tmp/
 
@@ -33,7 +33,7 @@ RUN apt-get update && apt-get install --no-install-recommends --no-install-sugge
 
 FROM nginx:1.22.0
 
-ENV NGX_MRUBY_VERSION 2.2.4
+ENV NGX_MRUBY_VERSION 2.2.5
 
 COPY --from=0 /usr/local/src/nginx-$NGINX_VERSION/objs/*.so /etc/nginx/modules/
 COPY nginx.conf /etc/nginx/nginx.conf


### PR DESCRIPTION
Update ngx_mruby to `v2.2.5` in stable nginx image.